### PR TITLE
Updated Astroid API + web2py modules in PYTHONPATH

### DIFF
--- a/README
+++ b/README
@@ -1,10 +1,11 @@
 A dead simple pylint plugin to avoid a lot of false positives when linting
 web2py applications.
 
-This version uses fresh Pylint API
-
+This version uses fresh Pylint API (>=1.2).
+Also it needs latest development version of Astroid (base Pylint library),
+particulary version after commit f0cdb29 (2014-11-10) which fixed module path resolution bug.
 
 To enable this plugin:
-* Add option `--load-plugins=pylint_web2py`
+- Add option `--load-plugins=pylint_web2py`
 or
-* Add `load-plugins=pylint_web2py` to your .pylintrc
+- Add `load-plugins=pylint_web2py` to your .pylintrc

--- a/README
+++ b/README
@@ -1,2 +1,10 @@
 A dead simple pylint plugin to avoid a lot of false positives when linting
 web2py applications.
+
+This version uses fresh Pylint API
+
+
+To enable this plugin:
+* Add option `--load-plugins=pylint_web2py`
+or
+* Add `load-plugins=pylint_web2py` to your .pylintrc

--- a/README
+++ b/README
@@ -1,10 +1,6 @@
 A dead simple pylint plugin to avoid a lot of false positives when linting
 web2py applications.
 
-This version uses fresh Pylint API (>=1.2).
-Also it needs latest development version of Astroid (base Pylint library),
-particulary version after commit f0cdb29 (2014-11-10) which fixed module path resolution bug.
-
 To enable this plugin:
 - Add option `--load-plugins=pylint_web2py`
 or

--- a/pylint_web2py/__init__.py
+++ b/pylint_web2py/__init__.py
@@ -1,10 +1,15 @@
-from logilab.astng import MANAGER
-from logilab.astng.builder import ASTNGBuilder
+from astroid import MANAGER
+from astroid import scoped_nodes
+from astroid.builder import AstroidBuilder
+import re
+
+web2py_component_regex = re.compile(r'.+?(models|views|controllers|modules)')
 
 def web2py_transform(module):
-    if 'controllers' in module.name or 'views' in module.name:
+    #Currently module.name and module.file are empty because of Astroid bug
+    if module.file and re.match(web2py_component_regex, module.file):
         # This dummy code is copied from gluon/__init__.py
-        fake = ASTNGBuilder(MANAGER).string_build('''\
+        fake = AstroidBuilder(MANAGER).string_build('''\
 from gluon.globals import current
 from gluon.html import *
 from gluon.validators import *
@@ -36,7 +41,5 @@ plugins = PluginManager()
 ''')
         module.locals.update(fake.locals)
 
-
-
 def register(linter):
-    MANAGER.register_transformer(web2py_transform)
+    MANAGER.register_transform(scoped_nodes.Module, web2py_transform)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     description=_short_description,
     version=_version,
     packages=_packages,
-    install_requires=['pylint<1.0'],
+    install_requires=['pylint>=1.2.0'],
     license='GPLv2',
     keywords='pylint web2py plugin',
 )

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,7 @@ setup(
     description=_short_description,
     version=_version,
     packages=_packages,
-    dependency_links=['hg+https://bitbucket.org/logilab/astroid/get/tip.zip#egg=astroid-1.2.2'],
-    install_requires=['astroid>=1.2.2', #Hack for pip to use mercurial version. When 1.2.2 is out, pip will use it
+    install_requires=['astroid>=1.3.0',
                       'pylint>=1.2.0'],
     license='GPLv2',
     keywords='pylint web2py plugin',

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-_version = '0.1.1'
+_version = '0.1.2'
 _packages = find_packages()
 _short_description = 'pylint-web2py is a Pylint plugin to help reduce false ' \
     'positives due to web2py implicit imports'
@@ -13,7 +13,9 @@ setup(
     description=_short_description,
     version=_version,
     packages=_packages,
-    install_requires=['pylint>=1.2.0'],
+    dependency_links=['hg+https://bitbucket.org/logilab/astroid/get/tip.zip#egg=astroid-1.2.2'],
+    install_requires=['astroid>=1.2.2', #Hack for pip to use mercurial version. When 1.2.2 is out, pip will use it
+                      'pylint>=1.2.0'],
     license='GPLv2',
     keywords='pylint web2py plugin',
 )


### PR DESCRIPTION
This version makes pylint-web2py work on latest Pylint with updated Astroid API.
Also it finds web2py module directories and adds them to PYTHONPATH, decreasing number of Pylint complaints about undefined objects.
